### PR TITLE
Add pack name setting, fix structure file extraction for completed packs

### DIFF
--- a/HoloPrint.js
+++ b/HoloPrint.js
@@ -37,7 +37,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 	console.info("Finished reading structure NBTs!");
 	console.log("NBTs:", nbts);
 	let structureSizes = nbts.map(nbt => nbt["size"].map(x => +x)); // Stored as Number instances: https://github.com/Offroaders123/NBTify/issues/50
-	let structureNames = structureFiles.map(structureFile => structureFile.name.replace(/(\.holoprint)?\.[^.]+$/, ""));
+	let packName = config.PACK_NAME ?? getDefaultPackName(structureFiles);
 	
 	// Make the pack
 	let loadedStuff = await loadStuff({
@@ -667,9 +667,9 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		}
 	})));
 	hudScreenUI["material_list"]["size"][1] = finalisedMaterialList.length * 12 + 12; // 12px for each item + 12px for the heading
-	hudScreenUI["material_list_heading"]["controls"][1]["pack_name"]["text"] += structureNames.join(", ");
+	hudScreenUI["material_list_heading"]["controls"][1]["pack_name"]["text"] += packName;
 	
-	manifest["header"]["name"] = `§uHoloPrint:§r ${structureNames.join(", ")}`;
+	manifest["header"]["name"] = packName;
 	manifest["header"]["description"] = `§u★HoloPrint§r resource pack generated on §o${(new Date()).toLocaleString()}§r\nDeveloped by §l§6SuperLlama88888§r`;
 	if(config.AUTHORS.length) {
 		manifest["header"]["description"] += `\nStructure made by ${config.AUTHORS.join(" and ")}`;
@@ -734,7 +734,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		});
 	}
 	
-	return new File([zippedPack], `${structureNames.join("+")}.holoprint.mcpack`);
+	return new File([zippedPack], `${packName}.holoprint.mcpack`);
 }
 /**
  * Retrieves the structure file from a completed HoloPrint resource pack
@@ -765,6 +765,18 @@ export async function updatePack(resourcePack, config, resourcePackStack, previe
 	}
 	return await makePack(structureFile, config, resourcePackStack, previewCont);
 }
+/**
+ * Returns the default pack name that would be used if no pack name is specified.
+ * @param {Array<File>} structureFiles
+ * @returns {String}
+ */
+export function getDefaultPackName(structureFiles) {
+	let defaultName = structureFiles.map(structureFile => structureFile.name.replace(/(\.holoprint)?\.[^.]+$/, "")).join(", ");
+	if(defaultName.length > 40) {
+		defaultName = `${defaultName.slice(0, 19)}...${defaultName.slice(-19)}`
+	}
+	return defaultName;
+}
 
 /**
  * Adds default config options to a potentially incomplete config object.
@@ -791,6 +803,7 @@ function addDefaultConfig(config) {
 			SPAWN_ANIMATION_LENGTH: 0.4, // in seconds
 			WRONG_BLOCK_OVERLAY_COLOR: [1, 0, 0, 0.3],
 			MATERIAL_LIST_LANGUAGE: "en_US",
+			PACK_NAME: undefined,
 			PACK_ICON_BLOB: undefined,
 			AUTHORS: [],
 			DESCRIPTION: undefined,
@@ -1266,6 +1279,7 @@ function stringifyWithFixedDecimals(value) {
  * @property {Number} SPAWN_ANIMATION_LENGTH Length of each individual block's spawn animation (seconds)
  * @property {Array<Number>} WRONG_BLOCK_OVERLAY_COLOR Clamped colour quartet
  * @property {String} MATERIAL_LIST_LANGUAGE The language code, as appearing in `texts/languages.json`
+ * @property {String|undefined} PACK_NAME The name of the completed pack; will default to the structure file names
  * @property {Blob} PACK_ICON_BLOB Blob for `pack_icon.png`
  * @property {Array<String>} AUTHORS
  * @property {String|undefined} DESCRIPTION

--- a/index.css
+++ b/index.css
@@ -129,6 +129,9 @@ input[type="number"], input[type="text"], textarea {
 	outline-width: thin;
 	accent-color: auto;
 }
+input[type="text"]::placeholder {
+	text-overflow: ellipsis;
+}
 button:not(:disabled):hover, input[type="file"]:not(:disabled):hover::file-selector-button, select:not(:disabled):hover, .buttonlike:hover {
 	background: #E8C8E8;
 }

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
 						<label for="metadataTab" class="buttonlike">Metadata</label>
 						<fieldset>
 							<legend>Metadata</legend>
+							<label>Pack name: <code><input type="text" name="packName"/></code></label>
 							<label>Pack icon (<code>*.png</code>): <input type="file" accept=".png" name="packIcon"/></label>
 							<label>Structure author: <input type="text" placeholder="MinecraftLover123" name="author"/></label>
 							<label>Description:<br/><textarea placeholder="This is my epic house!" rows="3" cols="20" name="description"></textarea></label>

--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ let dropFileNotice;
 let generatePackForm;
 let generatePackFormSubmitButton;
 let structureFilesInput;
+let packNameInput;
 let logger;
 
 let supabaseLogger;
@@ -47,6 +48,8 @@ document.onEvent("DOMContentLoaded", async () => {
 	generatePackForm = selectEl("#generatePackForm");
 	dropFileNotice = selectEl("#dropFileNotice");
 	structureFilesInput = generatePackForm.elements.namedItem("structureFiles");
+	packNameInput = generatePackForm.elements.namedItem("packName");
+	structureFilesInput.onEventAndNow("input", updatePackNameInputPlaceholder);
 	
 	if(location.search == "?loadFile") {
 		window.launchQueue?.setConsumer(async launchParams => {
@@ -152,16 +155,12 @@ async function handleInputFiles(files) {
 		[...structureFilesInput.files, ...structureFiles].forEach(structureFile => dataTransfer.items.add(structureFile));
 		structureFilesInput.files = dataTransfer.files;
 	}
+	updatePackNameInputPlaceholder();
+}
+function updatePackNameInputPlaceholder() {
+	packNameInput.setAttribute("placeholder", HoloPrint.getDefaultPackName([...structureFilesInput.files]));
 }
 
-async function handleLaunchFile(file) {
-	if(!file.name.endsWith(".mcstructure")) {
-		console.error(`File is not a structure file: ${file.name}`);
-		return;
-	}
-	let pack = await makePack([file]);
-	return pack;
-}
 async function temporarilyChangeText(el, text, duration = 2000) {
 	let originalText = el.innerText;
 	el.innerText = text;
@@ -188,6 +187,7 @@ async function makePack(structureFiles, localResourcePacks) {
 		TEXTURE_OUTLINE_ALPHA_DIFFERENCE_MODE: formData.get("textureOutlineAlphaDifferenceMode"),
 		DO_SPAWN_ANIMATION: formData.get("spawnAnimationEnabled"),
 		MATERIAL_LIST_LANGUAGE: formData.get("materialListLanguage"),
+		PACK_NAME: formData.get("packName") || undefined,
 		PACK_ICON_BLOB: formData.get("packIcon").size? formData.get("packIcon") : undefined,
 		AUTHORS: authors,
 		DESCRIPTION: formData.get("description") || undefined

--- a/index.js
+++ b/index.js
@@ -145,10 +145,8 @@ async function handleInputFiles(files) {
 	let resourcePacks = files.filter(file => file.name.endsWith(".mcpack"));
 	
 	for(let resourcePack of resourcePacks) {
-		let structureFile = await HoloPrint.extractStructureFileFromPack(resourcePack);
-		if(structureFile) {
-			structureFiles.push(structureFile);
-		}
+		let extractedStructureFiles = await HoloPrint.extractStructureFilesFromPack(resourcePack);
+		structureFiles.push(...extractedStructureFiles);
 	}
 	if(structureFiles.length) {
 		let dataTransfer = new DataTransfer();


### PR DESCRIPTION
- The final pack name can now be set in the Metadata tab.
- The in-game pack name will now no longer have "HoloPrint: " at the start, and if the default pack name is > 40 characters it will be shortened.
- Extraction of multiple structure files from packs with multiple structure files is now supported.
- Original file names for structure files are put in their comments, a really niche feature for only zip files apparently.