### PR TITLE
Add customisable in-game controls

### DIFF
--- a/.vscode/patchTypings.d.ts
+++ b/.vscode/patchTypings.d.ts
@@ -1,7 +1,11 @@
 // This solely exists so my patches of native classes like Response in essential.js have Intellisense support. Wish VSCode was smarter :/
 
 declare global {
-	interface HTMLElement {
+	interface Element {
+		selectEl(query: String): Element | null;
+		selectEls(query: String): NodeListOf<HTMLElement>;
+	}
+	interface DocumentFragment {
 		selectEl(query: String): Element | null;
 		selectEls(query: String): NodeListOf<HTMLElement>;
 	}

--- a/HoloPrint.js
+++ b/HoloPrint.js
@@ -364,7 +364,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		v.player_action_counter = 0;
 	}, { structureSize: structureSizes[0], defaultTextureIndex, structureCount: structureFiles.length }));
 	entityDescription["scripts"]["pre_animation"] ??= [];
-	entityDescription["scripts"]["pre_animation"].push(functionToMolang((v, q, t, textureBlobsCount, totalBlocksToValidate) => {
+	entityDescription["scripts"]["pre_animation"].push(functionToMolang((v, q, t, textureBlobsCount, totalBlocksToValidate, toggleRendering, changeOpacity, toggleValidating, changeLayer, decreaseLayer, changeStructure, disablePlayerControls) => {
 		v.hologram_dir = Math.floor(q.body_y_rotation / 90) + 2; // [south, west, north, east] (since it goes from -180 to 180)
 		
 		t.process_action = false; // this is the only place I'm using temp variables for their intended purpose
@@ -392,15 +392,15 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		}
 		
 		if(t.process_action) {
-			if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:stone")) {
+			if($[toggleRendering]) {
 				t.action = "toggle_rendering";
-			} else if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:glass")) {
+			} else if($[changeOpacity]) {
 				t.action = "increase_opacity";
-			} else if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:iron_ingot")) {
+			} else if($[toggleValidating]) {
 				t.action = "toggle_validating";
-			} else if(q.equipped_item_any_tag("slot.weapon.mainhand", "minecraft:planks")) {
+			} else if($[changeLayer]) {
 				t.action = "increase_layer";
-			} else if(q.equipped_item_any_tag("slot.weapon.mainhand", "minecraft:logs")) {
+			} else if($[decreaseLayer]) {
 				t.action = "decrease_layer";
 			} else if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:white_wool")) { // Movement controls (I hate that I'm having to do this)
 				t.action = "move_y-";
@@ -419,7 +419,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		t.player_action_counter ??= 0;
 		if(v.player_action_counter != t.player_action_counter && t.player_action_counter > 0 && t.player_action != "") {
 			v.player_action_counter = t.player_action_counter;
-			if(!q.is_item_name_any("slot.weapon.mainhand", "minecraft:bone")) {
+			if(!$[disablePlayerControls]) {
 				t.action = t.player_action;
 			}
 		}
@@ -524,7 +524,20 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 				v.wrong_block_z = t.wrong_block_z;
 			}
 		}
-	}, { textureBlobsCount: textureBlobs.length, totalBlocksToValidate: arrayToMolang(totalBlocksToValidateByStructure, "v.structure_index"), structureWMolang, structureHMolang, structureDMolang }));
+	}, {
+		textureBlobsCount: textureBlobs.length,
+		totalBlocksToValidate: arrayToMolang(totalBlocksToValidateByStructure, "v.structure_index"),
+		structureWMolang,
+		structureHMolang,
+		structureDMolang,
+		toggleRendering: itemCriteriaToMolang(config.CONTROLS.TOGGLE_RENDERING),
+		changeOpacity: itemCriteriaToMolang(config.CONTROLS.CHANGE_OPACITY),
+		toggleValidating: itemCriteriaToMolang(config.CONTROLS.TOGGLE_VALIDATING),
+		changeLayer: itemCriteriaToMolang(config.CONTROLS.CHANGE_LAYER),
+		decreaseLayer: itemCriteriaToMolang(config.CONTROLS.DECREASE_LAYER),
+		changeStructure: itemCriteriaToMolang(config.CONTROLS.CHANGE_STRUCTURE),
+		disablePlayerControls: itemCriteriaToMolang(config.CONTROLS.DISABLE_PLAYER_CONTROLS)
+	}));
 	entityDescription["geometry"]["hologram.wrong_block_overlay"] = "geometry.armor_stand.hologram.wrong_block_overlay";
 	entityDescription["geometry"]["hologram.valid_structure_overlay"] = "geometry.armor_stand.hologram.valid_structure_overlay";
 	entityDescription["geometry"]["hologram.particle_alignment"] = "geometry.armor_stand.hologram.particle_alignment";
@@ -576,25 +589,25 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		v.attack = v.attack_time > 0 && (v.last_attack_time == 0 || v.attack_time < v.last_attack_time);
 		v.last_attack_time = v.attack_time;
 	});
-	let renderingControls = functionToMolang((q, v) => {
+	let renderingControls = functionToMolang((q, v, toggleRendering, changeOpacity, toggleValidating, changeLayer, changeStructure) => {
 		if(v.attack) {
-			if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:stone")) {
+			if($[toggleRendering]) {
 				v.new_action = "toggle_rendering";
-			} else if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:glass")) {
+			} else if($[changeOpacity]) {
 				if(q.is_sneaking) {
 					v.new_action = "decrease_opacity";
 				} else {
 					v.new_action = "increase_opacity";
 				}
-			} else if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:iron_ingot")) {
+			} else if($[toggleValidating]) {
 				v.new_action = "toggle_validating";
-			} else if(q.equipped_item_any_tag("slot.weapon.mainhand", "minecraft:planks")) {
+			} else if($[changeLayer]) {
 				if(q.is_sneaking) {
 					v.new_action = "decrease_layer";
 				} else {
 					v.new_action = "increase_layer";
 				}
-			} else if(q.is_item_name_any("slot.weapon.mainhand", "minecraft:arrow")) {
+			} else if($[changeStructure]) {
 				if(q.is_sneaking) {
 					v.new_action = "previous_structure";
 				} else {
@@ -602,9 +615,15 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 				}
 			}
 		}
+	}, {
+		toggleRendering: itemCriteriaToMolang(config.CONTROLS.TOGGLE_RENDERING),
+		changeOpacity: itemCriteriaToMolang(config.CONTROLS.CHANGE_OPACITY),
+		toggleValidating: itemCriteriaToMolang(config.CONTROLS.TOGGLE_VALIDATING),
+		changeLayer: itemCriteriaToMolang(config.CONTROLS.CHANGE_LAYER),
+		changeStructure: itemCriteriaToMolang(config.CONTROLS.CHANGE_STRUCTURE)
 	});
-	let movementControls = functionToMolang((q, v) => {
-		if(v.attack && q.is_item_name_any("slot.weapon.mainhand", "minecraft:stick")) {
+	let movementControls = functionToMolang((q, v, moveHologram) => {
+		if(v.attack && $[moveHologram]) {
 			if(q.cardinal_player_facing == 0) { // this query unfortunately doesn't work in armour stands
 				v.new_action = "move_y-";
 			} else if(q.cardinal_player_facing == 1) {
@@ -619,6 +638,8 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 				v.new_action = "move_x-";
 			}
 		}
+	}, {
+		moveHologram: itemCriteriaToMolang(config.CONTROLS.MOVE_HOLOGRAM)
 	});
 	let broadcastActions = functionToMolang((v, t, q) => {
 		if(v.new_action != "") {
@@ -783,6 +804,21 @@ export function getDefaultPackName(structureFiles) {
 	}
 	return defaultName;
 }
+/**
+ * Creates an ItemCriteria from arrays of names and tags.
+ * @param {String|Array<String>} names
+ * @param {String|Array<String>} [tags]
+ * @returns {ItemCriteria}
+ */
+export function createItemCriteria(names, tags = []) { // IDK why I haven't made this a class
+	if(!Array.isArray(names)) {
+		names = [names];
+	}
+	if(!Array.isArray(tags)) {
+		tags = [tags];
+	}
+	return { names, tags };
+}
 
 /**
  * Adds default config options to a potentially incomplete config object.
@@ -808,6 +844,7 @@ function addDefaultConfig(config) {
 			DO_SPAWN_ANIMATION: true,
 			SPAWN_ANIMATION_LENGTH: 0.4, // in seconds
 			WRONG_BLOCK_OVERLAY_COLOR: [1, 0, 0, 0.3],
+			CONTROLS: {},
 			MATERIAL_LIST_LANGUAGE: "en_US",
 			PACK_NAME: undefined,
 			PACK_ICON_BLOB: undefined,
@@ -820,6 +857,17 @@ function addDefaultConfig(config) {
 		...{ // overrides (applied after)
 			IGNORED_BLOCKS: IGNORED_BLOCKS.concat(config.IGNORED_BLOCKS ?? []),
 			IGNORED_MATERIAL_LIST_BLOCKS: IGNORED_MATERIAL_LIST_BLOCKS.concat(config.IGNORED_MATERIAL_LIST_BLOCKS ?? []),
+			CONTROLS: {
+				TOGGLE_RENDERING: createItemCriteria("stone"),
+				CHANGE_OPACITY: createItemCriteria("glass"),
+				TOGGLE_VALIDATING: createItemCriteria("iron_ingot"),
+				CHANGE_LAYER: createItemCriteria([], "planks"),
+				DECREASE_LAYER: createItemCriteria([], "logs"),
+				MOVE_HOLOGRAM: createItemCriteria("stick"),
+				CHANGE_STRUCTURE: createItemCriteria("arrow"),
+				DISABLE_PLAYER_CONTROLS: createItemCriteria("bone"),
+				...config.CONTROLS
+			}
 		}
 	});
 }
@@ -1150,6 +1198,18 @@ async function makePackIcon(structureFile) {
 	return await can.convertToBlob();
 }
 /**
+ * Converts an item filter into a Molang expression representation.
+ * @param {ItemCriteria} itemCriteria
+ * @returns {String}
+ */
+function itemCriteriaToMolang(itemCriteria, slot = "slot.weapon.mainhand") {
+	let names = itemCriteria["names"].map(name => name.includes(":")? name : `minecraft:${name}`);
+	let tags = itemCriteria["tags"].map(tag => tag.includes(":")? tag : `minecraft:${tag}`);
+	let nameQuery = names.length > 0? `q.is_item_name_any('${slot}',${names.map(name => `'${name}'`).join(",")})` : undefined;
+	let tagQuery = tags.length > 0? `q.equipped_item_any_tag('${slot}',${tags.map(tag => `'${tag}'`).join(",")})` : undefined;
+	return [nameQuery, tagQuery].removeFalsies().join("||") || "false";
+}
+/**
  * Creates a Molang expression that mimics array access. Defaults to the last element if nothing is found.
  * @param {Array} array
  * @returns {String}
@@ -1284,6 +1344,7 @@ function stringifyWithFixedDecimals(value) {
  * @property {Boolean} DO_SPAWN_ANIMATION
  * @property {Number} SPAWN_ANIMATION_LENGTH Length of each individual block's spawn animation (seconds)
  * @property {Array<Number>} WRONG_BLOCK_OVERLAY_COLOR Clamped colour quartet
+ * @property {HoloPrintControlsConfig} CONTROLS
  * @property {String} MATERIAL_LIST_LANGUAGE The language code, as appearing in `texts/languages.json`
  * @property {String|undefined} PACK_NAME The name of the completed pack; will default to the structure file names
  * @property {Blob} PACK_ICON_BLOB Blob for `pack_icon.png`
@@ -1293,11 +1354,29 @@ function stringifyWithFixedDecimals(value) {
  * @property {Boolean} SHOW_PREVIEW_SKYBOX
  */
 /**
+ * Controls which items are used for in-game controls.
+ * @typedef {Object} HoloPrintControlsConfig
+ * @property {ItemCriteria} TOGGLE_RENDERING
+ * @property {ItemCriteria} CHANGE_OPACITY
+ * @property {ItemCriteria} TOGGLE_VALIDATING
+ * @property {ItemCriteria} CHANGE_LAYER Both for players and armour stands
+ * @property {ItemCriteria} DECREASE_LAYER Armour stand only
+ * @property {ItemCriteria} MOVE_HOLOGRAM For players in third-person
+ * @property {ItemCriteria} CHANGE_STRUCTURE For players only
+ * @property {ItemCriteria} DISABLE_PLAYER_CONTROLS
+ */
+/**
+ * Stores item names and tags for checking items. Leaving everything empty will check for nothing being held.
+ * @typedef {Object} ItemCriteria
+ * @property {Array<String>} names Item names the matching item could have. The `minecraft:` namespace will be used if no namespace is specified.
+ * @property {Array<String>} tags Item tags the matching item could have. The `minecraft:` namespace will be used if no namespace is specified.
+ */
+/**
  * A block palette entry, similar to how it appears in the NBT, as used in HoloPrint.
  * @typedef {Object} Block
  * @property {String} name The block's ID
- * @property {*} [states] Block states
- * @property {*} [block_entity_data] Block entity data
+ * @property {Object} [states] Block states
+ * @property {Object} [block_entity_data] Block entity data
  */
 /**
  * An unpositioned bone for geometry files without name or parent. All units/coordinates are relative to (0, 0, 0).

--- a/MaterialList.js
+++ b/MaterialList.js
@@ -102,7 +102,6 @@ export default class MaterialList {
 	 */
 	constructor(blockMetadata, itemMetadata, translations) {
 		this.materials = new Map();
-		
 		this.totalMaterialCount = 0;
 		
 		this.#blockMetadata = new Map(blockMetadata["data_items"].map(block => [block["name"], block]));
@@ -122,7 +121,7 @@ export default class MaterialList {
 		});
 	}
 	/**
-	 * Adds a material to the material list.
+	 * Adds a block to the material list.
 	 * @param {String} blockName
 	 * @param {Number} [count]
 	 */
@@ -135,6 +134,15 @@ export default class MaterialList {
 			itemName = itemName.replace("double_", "");
 			count *= 2;
 		}
+		this.materials.set(itemName, (this.materials.get(itemName) ?? 0) + count);
+		this.totalMaterialCount += count;
+	}
+	/**
+	 * Adds an item to the material list.
+	 * @param {String} itemName
+	 * @param {Number} [count]
+	 */
+	addItem(itemName, count = 1) {
 		this.materials.set(itemName, (this.materials.get(itemName) ?? 0) + count);
 		this.totalMaterialCount += count;
 	}
@@ -171,6 +179,13 @@ export default class MaterialList {
 				auxId: this.#findItemAuxId(itemName) ?? this.#findBlockAuxId(itemName) // this is used in the material list UI, so we prefer the item id
 			};
 		});
+	}
+	/**
+	 * Clears the material list.
+	 */
+	clear() {
+		this.materials.clear();
+		this.totalMaterialCount = 0;
 	}
 	/**
 	 * Finds an item serialization id.

--- a/essential.js
+++ b/essential.js
@@ -7,10 +7,10 @@ export const selectEl = selector => document.querySelector(selector);
 /** @returns {NodeListOf<HTMLElement>} */
 export const selectEls = selector => document.querySelectorAll(selector);
 
-HTMLElement.prototype.selectEl = function(query) {
+HTMLElement.prototype.selectEl = DocumentFragment.prototype.selectEl = function(query) {
 	return this.querySelector(query);
 };
-HTMLElement.prototype.selectEls = function(query) {
+HTMLElement.prototype.selectEls = DocumentFragment.prototype.selectEls = function(query) {
 	return this.querySelectorAll(query);
 };
 
@@ -112,6 +112,9 @@ export function addOrdinalSuffix(num) {
 	return num + (num % 10 == 1 && num % 100 != 11? "st" : num % 10 == 2 && num % 100 != 12? "nd" : num % 10 == 3 && num % 100 != 13? "rd" : "th");
 }
 
+export function htmlCodeToElement(htmlCode) {
+	return (new DOMParser()).parseFromString(htmlCode, "text/html").body.firstElementChild;
+}
 export function stringToImageData(text, textCol = "black", backgroundCol = "white", font = "12px monospace") {
 	let can = new OffscreenCanvas(0, 20);
 	let ctx = can.getContext("2d");
@@ -277,5 +280,37 @@ export class JSONMap extends Map { // very barebones
 	}
 	#stringify(value) {
 		return JSON.stringify(value, this.#replacer);
+	}
+}
+export class CachingFetcher {
+	cacheName;
+	#baseUrl;
+	#cache;
+	constructor(cacheName, baseUrl = "") {
+		return (async () => {
+			this.#cache = await caches.open(cacheName);
+			this.#baseUrl = baseUrl;
+			this.cacheName = cacheName;
+			
+			return this;
+		})();
+	}
+	/**
+	 * Fetches a file.
+	 * @param {String} url
+	 * @returns {Promise<Response>}
+	 */
+	async fetch(url) {
+		let fullUrl = this.#baseUrl + url;
+		let cacheLink = `https://cache/${url}`;
+		let res = await this.#cache.match(cacheLink);
+		if(!res) {
+			res = await this.retrieve(fullUrl);
+			this.#cache.put(cacheLink, res.clone()).catch(e => console.warn(`Failed to save response from ${fullUrl} to cache ${this.cacheName}:`, e));
+		}
+		return res;
+	}
+	async retrieve(url) {
+		return await fetch(url);
 	}
 }

--- a/essential.js
+++ b/essential.js
@@ -296,7 +296,7 @@ export class CachingFetcher {
 		})();
 	}
 	/**
-	 * Fetches a file.
+	 * Fetches a file, checking first against cache.
 	 * @param {String} url
 	 * @returns {Promise<Response>}
 	 */
@@ -310,6 +310,11 @@ export class CachingFetcher {
 		}
 		return res;
 	}
+	/**
+	 * Actually load a file, for when it's not found in cache.
+	 * @param {String} url
+	 * @returns {Promise<Response>}
+	 */
 	async retrieve(url) {
 		return await fetch(url);
 	}

--- a/index.css
+++ b/index.css
@@ -96,6 +96,46 @@ form {
 fieldset:has(#structureFilesInput:invalid) ~ * {
 	display: none;
 }
+fieldset.expandable {
+	display: grid;
+	grid-template-rows: 0fr;
+	transition: grid-template-rows 0.35s;
+}
+fieldset.expandable:has(input:checked) {
+	grid-template-rows: 1fr;
+}
+fieldset.expandable > *:not(legend) {
+	overflow: hidden;
+}
+fieldset.expandable > legend {
+	contain: layout;
+}
+fieldset.expandable > legend > label {
+	padding-left: 1em;
+	cursor: pointer;
+}
+fieldset.expandable > legend > label > input {
+	display: none;
+}
+fieldset.expandable > legend::before {
+	content: "";
+	margin: auto;
+	display: inline-block;
+	position: absolute;
+	left: 3px;
+	top: 3px;
+	bottom: 0;
+	width: 0.5em;
+	height: 0.5em;
+	border-right: 1px solid currentColor;
+	border-top: 1px solid currentColor;
+	transform: rotate(45deg);
+	transform-origin: 75% 25%;
+	transition: transform 0.35s;
+}
+fieldset.expandable:has(input:checked) > legend::before {
+	transform: rotate(135deg);
+}
 label {
 	display: block;
 }

--- a/index.html
+++ b/index.html
@@ -38,24 +38,39 @@
 								<option value="en_US" selected>English (United States)</option>
 							</select></label>
 							<label>Hologram scale: <input type="number" min="70" max="100" step="1" value="95" name="scale"/>%</label>
-							<fieldset>
-								<legend>Textures</legend>
-								<label>Texture outline width: <select name="textureOutlineWidth">
-									<option value="0">None</option>
-									<option value="0.125">0.125px</option>
-									<option value="0.25" selected>0.25px</option>
-									<option value="0.5">0.5px</option>
-									<option value="1">1px</option>
-								</select></label>
-								<label>Texture outline color: <input type="text" value="#00FA" name="textureOutlineColor"/></label>
-								<details>
-									<summary>Advanced</summary>
-									<label>Texture outline alpha threshold: <input type="number" min="0" max="255" value="0" name="textureOutlineAlphaThreshold"></label>
-									<label>Texture outline alpha comparison mode: <select name="textureOutlineAlphaDifferenceMode">
-										<option value="threshold" selected>Threshold</option>
-										<option value="difference">Difference</option>
+							<fieldset class="expandable">
+								<legend><label>Textures<input type="checkbox"/></label></legend>
+								<div>
+									<label>Texture outline width: <select name="textureOutlineWidth">
+										<option value="0">None</option>
+										<option value="0.125">0.125px</option>
+										<option value="0.25" selected>0.25px</option>
+										<option value="0.5">0.5px</option>
+										<option value="1">1px</option>
 									</select></label>
-								</details>
+									<label>Texture outline color: <input type="text" value="#00FA" name="textureOutlineColor"/></label>
+									<details>
+										<summary>Advanced</summary>
+										<label>Texture outline alpha threshold: <input type="number" min="0" max="255" value="0" name="textureOutlineAlphaThreshold"></label>
+										<label>Texture outline alpha comparison mode: <select name="textureOutlineAlphaDifferenceMode">
+											<option value="threshold" selected>Threshold</option>
+											<option value="difference">Difference</option>
+										</select></label>
+									</details>
+								</div>
+							</fieldset>
+							<fieldset class="expandable">
+								<legend><label>In-game controls<input type="checkbox"/></label></legend>
+								<div>
+									<label>Toggle rendering:<item-criteria-input name="toggleRenderingControls" value-items="stone"></item-criteria-input></label>
+									<label>Change opacity:<item-criteria-input name="changeOpacityControls" value-items="glass"></item-criteria-input></label>
+									<label>Toggle validating:<item-criteria-input name="toggleValidatingControls" value-items="iron_ingot"></item-criteria-input></label>
+									<label>Change layer:<item-criteria-input name="changeLayerControls" value-tags="planks"></item-criteria-input></label>
+									<label>Decrease layer:<item-criteria-input name="decreaseLayerControls" value-tags="logs"></item-criteria-input></label>
+									<label>Move hologram:<item-criteria-input name="moveHologramControls" value-items="stick"></item-criteria-input></label>
+									<label>Change structure:<item-criteria-input name="changeStructureControls" value-items="arrow"></item-criteria-input></label>
+									<label>Disable player controls:<item-criteria-input name="disablePlayerControlsControls" value-items="bone"></item-criteria-input></label>
+								</div>
 							</fieldset>
 							<label>Spawn animation: <input type="checkbox" name="spawnAnimationEnabled" checked/></label>
 							<label>Ignored blocks: <input type="text" name="ignoredBlocks" placeholder="block_1 block_2 etc."/></label>

--- a/index.html
+++ b/index.html
@@ -61,16 +61,7 @@
 							</fieldset>
 							<fieldset class="expandable">
 								<legend><label>In-game controls<input type="checkbox"/></label></legend>
-								<div>
-									<label>Toggle rendering:<item-criteria-input name="toggleRenderingControls" value-items="stone"></item-criteria-input></label>
-									<label>Change opacity:<item-criteria-input name="changeOpacityControls" value-items="glass"></item-criteria-input></label>
-									<label>Toggle validating:<item-criteria-input name="toggleValidatingControls" value-items="iron_ingot"></item-criteria-input></label>
-									<label>Change layer:<item-criteria-input name="changeLayerControls" value-tags="planks"></item-criteria-input></label>
-									<label>Decrease layer:<item-criteria-input name="decreaseLayerControls" value-tags="logs"></item-criteria-input></label>
-									<label>Move hologram:<item-criteria-input name="moveHologramControls" value-items="stick"></item-criteria-input></label>
-									<label>Change structure:<item-criteria-input name="changeStructureControls" value-items="arrow"></item-criteria-input></label>
-									<label>Disable player controls:<item-criteria-input name="disablePlayerControlsControls" value-items="bone"></item-criteria-input></label>
-								</div>
+								<div id="playerControlsInputCont"></div>
 							</fieldset>
 							<label>Spawn animation: <input type="checkbox" name="spawnAnimationEnabled" checked/></label>
 							<label>Ignored blocks: <input type="text" name="ignoredBlocks" placeholder="block_1 block_2 etc."/></label>

--- a/index.js
+++ b/index.js
@@ -107,6 +107,22 @@ document.onEvent("DOMContentLoaded", async () => {
 		generatePackForm.elements.namedItem("opacity").parentElement.classList.toggle("hidden", opacityModeSelect.value == "multiple");
 	});
 	
+	let playerControlsInputCont = selectEl("#playerControlsInputCont");
+	Object.entries(HoloPrint.DEFAULT_PLAYER_CONTROLS).forEach(([control, itemCriteria]) => {
+		let label = document.createElement("label");
+		label.innerText = `${HoloPrint.PLAYER_CONTROL_NAMES[control]}:`;
+		let input = document.createElement("item-criteria-input");
+		input.setAttribute("name", `control.${control}`);
+		if(itemCriteria["names"].length > 0) {
+			input.setAttribute("value-items", itemCriteria["names"].join(","));
+		}
+		if(itemCriteria["tags"].length > 0) {
+			input.setAttribute("value-tags", itemCriteria["tags"].join(","));
+		}
+		label.appendChild(input);
+		playerControlsInputCont.appendChild(label);
+	});
+	
 	let clearResourcePackCacheButton = selectEl("#clearResourcePackCacheButton");
 	clearResourcePackCacheButton.onEvent("click", async () => {
 		caches.clear();
@@ -186,16 +202,7 @@ async function makePack(structureFiles, localResourcePacks) {
 		TEXTURE_OUTLINE_ALPHA_THRESHOLD: +formData.get("textureOutlineAlphaThreshold"),
 		TEXTURE_OUTLINE_ALPHA_DIFFERENCE_MODE: formData.get("textureOutlineAlphaDifferenceMode"),
 		DO_SPAWN_ANIMATION: formData.get("spawnAnimationEnabled"),
-		CONTROLS: {
-			TOGGLE_RENDERING: JSON.parse(formData.get("toggleRenderingControls")),
-			CHANGE_OPACITY: JSON.parse(formData.get("changeOpacityControls")),
-			TOGGLE_VALIDATING: JSON.parse(formData.get("toggleValidatingControls")),
-			CHANGE_LAYER: JSON.parse(formData.get("changeLayerControls")),
-			DECREASE_LAYER: JSON.parse(formData.get("decreaseLayerControls")),
-			MOVE_HOLOGRAM: JSON.parse(formData.get("moveHologramControls")),
-			CHANGE_STRUCTURE: JSON.parse(formData.get("changeStructureControls")),
-			DISABLE_PLAYER_CONTROLS: JSON.parse(formData.get("disablePlayerControlsControls"))
-		},
+		CONTROLS: Object.fromEntries([...formData].filter(([key]) => key.startsWith("control.")).map(([key, value]) => [key.replace(/^control./, ""), JSON.parse(value)])),
 		MATERIAL_LIST_LANGUAGE: formData.get("materialListLanguage"),
 		PACK_NAME: formData.get("packName") || undefined,
 		PACK_ICON_BLOB: formData.get("packIcon").size? formData.get("packIcon") : undefined,

--- a/index.js
+++ b/index.js
@@ -212,13 +212,15 @@ async function makePack(structureFiles, localResourcePacks) {
 		supabaseLogger ??= new SupabaseLogger(supabaseProjectUrl, supabaseApiKey);
 		supabaseLogger.recordPackCreation(structureFiles);
 	}
-
-	let downloadButton = document.createElement("button");
-	downloadButton.classList.add("importantButton");
-	downloadButton.innerText = `Download ${pack.name}`;
-	downloadButton.onclick = () => downloadBlob(pack, pack.name);
-	downloadButton.click();
-	document.body.appendChild(downloadButton);
+	
+	if(pack) {
+		let downloadButton = document.createElement("button");
+		downloadButton.classList.add("importantButton");
+		downloadButton.innerText = `Download ${pack.name}`;
+		downloadButton.onclick = () => downloadBlob(pack, pack.name);
+		downloadButton.click();
+		document.body.appendChild(downloadButton);
+	}
 	
 	generatePackFormSubmitButton.disabled = false;
 	


### PR DESCRIPTION
- Add a pure-CSS expandable `<fieldset>` for changing controls. The texture options have also been changed to be expandable.
- Each control can be changed to match any number of items or item tags. Inputs are distinguishable by colour. When tested with Firefox accessibility tools, they seem to still be distinguishable even with colourblindness.
  - Inputs are using custom form elements, and have `<datalist>`s to show all item names and tages. Item tags are grabbed from pmmp/BedrockData.
- Add a generalised CachingFetcher class to make caching resource easier.
- Using a fake material list to translate item names, a list of in-game controls are added to the pack description if they are different to the default.