### PR TITLE
Fix validation particles flickering in certain situations

### DIFF
--- a/HoloPrint.js
+++ b/HoloPrint.js
@@ -1045,10 +1045,10 @@ function addBlockValidationParticles(hologramAnimationControllers, structureI, b
 		validateAllState["particle_effects"].push(particleEffect);
 		validationStates[animationStateName]["particle_effects"].push(particleEffect);
 	});
-	for(let y = 0; y < structureSize[1]; y++) {
+	for(let y = 0; y < structureSize[1]; y++) { // layers with no blocks to validate don't have an animation controller state, so transitions to the default state need to be added for when it's on these empty layers
 		if(!layersWithBlocksToValidate.includes(y)) {
 			Object.entries(validationStates).forEach(([validationStateName, validationState]) => {
-				if(validationStateName != "default") {
+				if(validationStateName.startsWith(`validate_${structureI}`)) {
 					validationState["transitions"][0]["default"] += ` || v.hologram.layer == ${y}`;
 				}
 			});

--- a/entityScripts.molang.js
+++ b/entityScripts.molang.js
@@ -30,6 +30,7 @@ export function armorStandInitialization() {
 	v.last_hurt_direction = q.hurt_direction;
 	// v.player_action_counter = t.player_action_counter ?? 0;
 	v.player_action_counter = 0;
+	v.hologram_dir = 0;
 	
 	v.spawn_time = q.time_stamp;
 	v.player_has_interacted = false;


### PR DESCRIPTION
- In a multi-structure pack, if another structure had an empty layer (i.e. no blocks to validate), being on validation mode on that layer but with another structure would cause the animation controller state to go back and forth.
- Also fixed content log issue regarding v.hologram_dir being undefined in punch-to-activate mode.
- I tried to make the wrong block overlay only show for the hologram that it belongs to by giving each armour stand a UUID and temp leaking it to the particles via `on_entry`; however, it seems to get messed up with multiple armour stands, defeating the purpose.