### PR TITLE
Fix extremely large structures causing stack overflows (#101)

### DIFF
--- a/HoloPrint.js
+++ b/HoloPrint.js
@@ -7,7 +7,7 @@ import MaterialList from "./MaterialList.js";
 import PreviewRenderer from "./PreviewRenderer.js";
 
 import * as entityScripts from "./entityScripts.molang.js";
-import { addPaddingToImage, awaitAllEntries, CachingFetcher, concatenateFiles, createNumericEnum, exp, floor, hexColorToClampedTriplet, JSONMap, JSONSet, lcm, loadTranslationLanguage, max, min, overlaySquareImages, pi, resizeImageToBlob, round, sha256, translate, UserError } from "./essential.js";
+import { addPaddingToImage, arrayMin, awaitAllEntries, CachingFetcher, concatenateFiles, createNumericEnum, exp, floor, hexColorToClampedTriplet, JSONMap, JSONSet, lcm, loadTranslationLanguage, max, min, overlaySquareImages, pi, resizeImageToBlob, round, sha256, translate, UserError } from "./essential.js";
 import ResourcePackStack from "./ResourcePackStack.js";
 import BlockUpdater from "./BlockUpdater.js";
 
@@ -432,7 +432,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		hologramGeo["minecraft:geometry"].push(geo);
 		
 		if(config.SPAWN_ANIMATION_ENABLED && structureI == 0) {
-			let minDelay = min(...spawnAnimationAnimatedBones.map(([, delay]) => delay));
+			let minDelay = arrayMin(spawnAnimationAnimatedBones.map(([, delay]) => delay));
 			spawnAnimationAnimatedBones.forEach(([boneName, delay, bonePos]) => {
 				delay -= minDelay - 0.05;
 				delay = Number(delay.toFixed(2));

--- a/components/SimpleLogger.js
+++ b/components/SimpleLogger.js
@@ -127,11 +127,11 @@ export default class SimpleLogger extends HTMLElement {
 			level: logLevel,
 			stackTrace
 		});
-		let currentURLOrigin = location.href.slice(0, location.href.lastIndexOf("/")); // location.origin is null on Firefox when on local files
-		if(stackTrace.some(loc => !loc.includes(currentURLOrigin) && !loc.includes("<anonymous>"))) {
+		if(logLevel == "debug") {
 			return;
 		}
-		if(logLevel == "debug") {
+		let currentURLOrigin = location.href.slice(0, location.href.lastIndexOf("/")); // location.origin is null on Firefox when on local files
+		if(stackTrace.some(loc => /https?:\/\//.test(loc) && !loc.includes(currentURLOrigin) && !loc.includes("<anonymous>"))) {
 			return;
 		}
 		let el = document.createElement("p");

--- a/essential.js
+++ b/essential.js
@@ -151,6 +151,13 @@ export const clamp = (n, lowest, highest) => min(max(n, lowest), highest);
 export const lerp = (a, b, x) => a + (b - a) * x;
 export const nanToUndefined = x => Number.isNaN(x)? undefined : x;
 
+export function arrayMin(arr) {
+	let min = Infinity;
+	for(let i = 0; i < arr.length; i++) {
+		min = min < arr[i]? min : arr[i];
+	}
+	return min;
+}
 export function range(a, b, c) {
 	if(b == undefined && c == undefined) {
 		return (new Array(a + 1)).fill().map((x, i) => i);


### PR DESCRIPTION
Closes #101: In Firefox, functions can have at most 500000 parameters; and in Chromium, function parameters are put on a stack, which has a limit of around around 120000. This meant that the spawn animation logic, which removes the initial delay by finding when the first ghost block starts animating, crashed pack generation when there were lots of blocks (I'm talking 814149). This has been fixed with an imperative min function that works limitlessly for arrays.
Also fix the "~ blocks upgraded" info log from not showing up in Chromium browsers.