### PR TITLE
Make non-mcstructure files invalid, add sugar cane tint

### DIFF
--- a/data/textureAtlasMappings.json
+++ b/data/textureAtlasMappings.json
@@ -52,6 +52,10 @@
 				"tint": "foliage",
 				"tint_like_png": true
 			},
+			"reeds": {
+				"tint": "foliage",
+				"tint_like_png": true
+			},
 			"jungle_leaves": {
 				"tint": "#57BE08",
 				"tint_like_png": true

--- a/index.css
+++ b/index.css
@@ -82,8 +82,12 @@ form {
 		padding: 5px;
 	}
 }
-#structureFilesInput:invalid {
+#structureFilesInput:invalid:not(.wrongFileType) {
 	display: none; /* The label will make the button work */
+}
+#structureFilesInput.wrongFileType {
+	color: #E24436;
+	outline: 3px solid #E24436;
 }
 #structureFilesInput ~ div {
 	margin: 4px auto;
@@ -104,13 +108,13 @@ form {
 #structureFilesInput ~ div p:last-child {
 	font-size: 0.7em;
 }
-#structureFilesInput:valid ~ div {
+#structureFilesInput:valid ~ div, #structureFilesInput.wrongFileType ~ div {
 	display: none;
 }
-form:has(#structureFilesInput:invalid) ~ * {
+form:has(#structureFilesInput:invalid:not(.wrongFileType)) ~ * {
 	display: none;
 }
-fieldset:has(#structureFilesInput:invalid) ~ * {
+fieldset:has(#structureFilesInput:invalid:not(.wrongFileType)) ~ * {
 	display: none;
 }
 fieldset.expandable {
@@ -182,7 +186,7 @@ button, input[type="checkbox"], input[type="number"], input[type="text"], textar
 	background: #EEDEEE;
 	font-family: inherit;
 	cursor: pointer;
-	transition: background 0.15s, border-color 0.225s;
+	transition: background 0.15s, border-color 0.15s;
 }
 input[type="color"] {
 	border: 2px solid #D899D8;
@@ -262,30 +266,30 @@ input[type="checkbox"]:hover::after {
 	top: 0;
 }
 
-#configTabsCont {
+.multiTabCont {
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-evenly;
 }
-#configTabsCont input[type="radio"][name="configTabs"] {
+.multiTabCont > input[type="radio"][name^="configTabs"] {
 	position: absolute; /* stay at top */
 	opacity: 0;
 }
-#configTabsCont > label {
+.multiTabCont > label {
 	flex: 1 1 0;
 	text-align: center;
 	margin: 10px 5px 5px;
 }
-#configTabsCont > fieldset {
+.multiTabCont > fieldset {
 	width: 100%;
 	order: 1;
 	contain: layout;
 }
-#configTabsCont input[type="radio"][name="configTabs"]:checked + label {
+.multiTabCont > input[type="radio"][name^="configTabs"]:checked + label {
 	background: #E8C8E8;
 	font-weight: 500;
 }
-#configTabsCont input[type="radio"][name="configTabs"]:not(:checked) + label + fieldset {
+.multiTabCont > input[type="radio"][name^="configTabs"]:not(:checked) + label + fieldset {
 	display: none;
 }
 

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
 								<div class="buttonlike"><p data-translate="upload.button">Upload a file</p><p data-translate="upload.button.drop_notice">Or drop files here</p></div>
 							</label>
 						</fieldset>
-						<div id="configTabsCont">
+						<div class="multiTabCont">
 							<input type="radio" checked name="configTabs" form="" id="settingsTab"/>
 							<label for="settingsTab" class="buttonlike" data-translate="settings.heading">Settings</label>
 							<fieldset>

--- a/index.js
+++ b/index.js
@@ -37,8 +37,10 @@ window.OffscreenCanvas ?? class OffscreenCanvas {
 
 let dropFileNotice;
 
+/** @type {HTMLFormElement} */
 let generatePackForm;
 let generatePackFormSubmitButton;
+/** @type {HTMLInputElement} */
 let structureFilesInput;
 let packNameInput;
 let completedPacksCont;
@@ -65,6 +67,15 @@ document.onEvent("DOMContentLoaded", () => {
 		packNameInput.setCustomValidity("");
 	});
 	structureFilesInput.onEventAndNow("input", updatePackNameInputPlaceholder);
+	structureFilesInput.onEventAndNow("change", () => {
+		if([...structureFilesInput.files].some(file => !file.name.endsWith(".mcstructure"))) {
+			structureFilesInput.setCustomValidity("Please upload only .mcstructure files.");
+			structureFilesInput.classList.add("wrongFileType"); // CSS styling uses :invalid to detect the empty input and show the large label, but it shouldn't be shown if it's invalid because the user has uploaded the wrong file type
+		} else {
+			structureFilesInput.setCustomValidity("");
+			structureFilesInput.classList.remove("wrongFileType");
+		}
+	});
 	completedPacksCont = selectEl("#completedPacksCont");
 	texturePreviewImageCont = selectEl("#texturePreviewImageCont");
 	defaultResourcePackStackPromise = new ResourcePackStack();
@@ -374,6 +385,11 @@ async function temporarilyChangeText(el, translationKey, duration = 2000) {
 	el.removeAttribute("disabled");
 }
 
+/**
+ * @param {Array<File>} structureFiles
+ * @param {Array<LocalResourcePack>} localResourcePacks
+ * @returns {Promise<void>}
+ */
 async function makePack(structureFiles, localResourcePacks) {
 	// this is a mess. all it does is get the settings, call HoloPrint.makePack(), and show the download button.
 	generatePackFormSubmitButton.disabled = true;
@@ -468,6 +484,4 @@ async function makePack(structureFiles, localResourcePacks) {
 	}
 	
 	generatePackFormSubmitButton.disabled = false;
-	
-	return pack;
 }


### PR DESCRIPTION
Unfortunately, <input type="file" accept="..."/>s aren't automatically invalidated when files with non-matching file extensions are selected.