### PR TITLE
Fix massive lag, refactor to poly_mesh

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Special thanks to **kizoku246** for the house in these images!
 ### Credit
 - [Structura](https://github.com/RavinMaddHatter/Structura): Inspiration, laying the foundation for this project. Without the work of [RavinMaddHatter](https://github.com/RavinMaddHatter) and [others](https://github.com/RavinMaddHatter/Structura/graphs/contributors), this project would've taken tens of hours more to get started.
 - [Tab Key Playerlist UI](https://github.com/YuuhaLand/Tabkey_Playerlist_UI) by [YuuhaLand](https://github.com/YuuhaLand): Foundation for the material list UI
+- Nextr: Control item textures (tweaked)
 - [Indyfficient](https://www.youtube.com/@Indyfficient): The idea of changing structure by hitting the armour stand
 - [Prowl8413](https://www.youtube.com/@Prowl8413): General feedback during development
 - Documentation:
@@ -76,6 +77,9 @@ Special thanks to **kizoku246** for the house in these images!
   - [tga.js](https://github.com/vthibault/tga.js): TGA to PNG image conversion
   - [potpack](https://github.com/mapbox/potpack): Texture atlas packing
   - [JSZip](https://github.com/Stuk/jszip): Pack zipping
-  - [bridge-model-viewer](https://github.com/bridge-core/model-viewer) and [three.js](https://github.com/mrdoob/three.js): Preview rendering
+  - [Minecraft Creator Tools](https://github.com/Mojang/minecraft-creator-tools): LevelDB reader
+  - [three.js](https://github.com/mrdoob/three.js): Preview rendering
+  - [stats.js](https://github.com/mrdoob/stats.js) and [lil-gui](https://github.com/georgealways/lil-gui): Preview widgets
+  - [Supabase](https://supabase.com): Free database for recording packs created
   - [strip-json-comments](https://github.com/sindresorhus/strip-json-comments): Removes comments from JSON files
   - [deepmerge](https://github.com/TehShrike/deepmerge): Merges JSON files

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,6 +63,7 @@
 ### 致谢
 - [Structura](https://github.com/RavinMaddHatter/Structura)：灵感来源与项目基础，特别感谢 [RavinMaddHatter](https://github.com/RavinMaddHatter) 以及 [其他贡献者](https://github.com/RavinMaddHatter/Structura/graphs/contributors)。
 - [Tab键玩家列表UI](https://github.com/YuuhaLand/Tabkey_Playerlist_UI)：材料清单 UI 的底层实现。（作者 [YuuhaLand](https://github.com/YuuhaLand)）
+- Nextr: Control item textures (tweaked)
 - [Indyfficient](https://www.youtube.com/@Indyfficient)：通过攻击盔甲架切换结构的创意。
 - [Prowl8413](https://www.youtube.com/@Prowl8413)：开发过程中的反馈支持。
 - **参考文档：**
@@ -76,6 +77,9 @@
   - [tga.js](https://github.com/vthibault/tga.js): TGA 到 PNG 的图片转换。
   - [potpack](https://github.com/mapbox/potpack)：纹理图集打包。
   - [JSZip](https://github.com/Stuk/jszip)：压缩打包。
-  - [bridge-model-viewer](https://github.com/bridge-core/model-viewer) 与 [three.js](https://github.com/mrdoob/three.js)：3D 预览渲染。
+  - [Minecraft Creator Tools](https://github.com/Mojang/minecraft-creator-tools): LevelDB reader
+  - [three.js](https://github.com/mrdoob/three.js)：3D 预览渲染。
+  - [stats.js](https://github.com/mrdoob/stats.js) and [lil-gui](https://github.com/georgealways/lil-gui): Preview widgets
+  - [Supabase](https://supabase.com): Free database for recording packs created
   - [strip-json-comments](https://github.com/sindresorhus/strip-json-comments)：JSON 注释清理。
   - [deepmerge](https://github.com/TehShrike/deepmerge)：JSON 合并工具。

--- a/pipeline/build.js
+++ b/pipeline/build.js
@@ -94,7 +94,6 @@ function findProcessingFunction(filename) {
  * @returns {{ code: string }}
  */
 function processHTML(code, filename) {
-	// code = code.replaceAll(/<style>([^]+?)<\/style>/g, (_, css) => `<style>${processCSS(css, filename, true).code}</style>`);
 	code = code.replaceAll(/<script type="(importmap|application\/ld\+json)">([^]+?)<\/script>/g, (_, scriptType, json) => `<script type="${scriptType}">${processJSON(json).code}</script>`);
 	code = minifyHTML(code, {
 		removeComments: true,

--- a/src/BlockGeoMaker.js
+++ b/src/BlockGeoMaker.js
@@ -899,11 +899,11 @@ export default class BlockGeoMaker extends AsyncFactory {
 	static resolveTemplateFaceUvs(faces, textureAtlas) {
 		return faces.map(face => {
 			let imageUv = textureAtlas.uvs[face["textureRefI"]];
+			face["vertices"].sort((a, b) => a["corner"] - b["corner"]);
 			if("crop" in imageUv) {
 				this.#applyFaceCropping(face, imageUv["crop"]);
 			}
-			let sortedVertices = face["vertices"].sort((a, b) => a["corner"] - b["corner"]);
-			let vertices = [sortedVertices[0], sortedVertices[1], sortedVertices[3], sortedVertices[2]]; // go around in a square
+			let vertices = [face["vertices"][0], face["vertices"][1], face["vertices"][3], face["vertices"][2]]; // go around in a square
 			return {
 				"normal": face["normal"],
 				"vertices": vertices.map(vertex => ({

--- a/src/BlockGeoMaker.js
+++ b/src/BlockGeoMaker.js
@@ -680,13 +680,13 @@ export default class BlockGeoMaker extends AsyncFactory {
 		cubes.forEach(cube => {
 			let mass = cube.w * cube.h * cube.d; // assume uniform mass density
 			totalMass += mass;
-			center = addVec3(center, mulVec3(addVec3(cube["pos"], cube["size"]), mass / 2));
+			center = addVec3(center, mulVec3(addVec3(cube["pos"], mulVec3(cube["size"], 0.5)), mass));
 		});
 		if(totalMass == 0) { // all cubes must be flat
 			cubes.forEach(cube => {
 				let mass = max(cube.w, 1) * max(cube.h, 1) * max(cube.d, 1);
 				totalMass += mass;
-				center = addVec3(center, mulVec3(addVec3(cube["pos"], cube["size"]), mass / 2));
+				center = addVec3(center, mulVec3(addVec3(cube["pos"], mulVec3(cube["size"], 0.5)), mass));
 			});
 		}
 		if(totalMass == 0) {

--- a/src/BlockUpdater.js
+++ b/src/BlockUpdater.js
@@ -243,24 +243,4 @@ export default class BlockUpdater extends AsyncFactory {
 	}
 }
 
-/**
- * @typedef {import("./HoloPrint.js").NBTBlock} NBTBlock
- */
-/**
- * @typedef {import("./BlockGeoMaker.js").Block} Block
- */
-/**
- * @typedef {import("./HoloPrint.js").BlockUpdateSchemaSkeleton} BlockUpdateSchemaSkeleton
- */
-/**
- * @typedef {import("./HoloPrint.js").BlockUpdateSchema} BlockUpdateSchema
- */
-/**
- * @typedef {import("./HoloPrint.js").TypedBlockStateProperty} TypedBlockStateProperty
- */
-/**
- * @typedef {import("./HoloPrint.js").BlockUpdateSchemaFlattenRule} BlockUpdateSchemaFlattenRule
- */
-/**
- * @typedef {import("./HoloPrint.js").BlockUpdateSchemaRemappedState} BlockUpdateSchemaRemappedState
- */
+/** @import { NBTBlock, Block, BlockUpdateSchemaSkeleton, BlockUpdateSchema, TypedBlockStateProperty, BlockUpdateSchemaFlattenRule } from "./HoloPrint.js" */

--- a/src/HoloPrint.js
+++ b/src/HoloPrint.js
@@ -468,7 +468,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 			}));
 			previewLoadedCallback?.(previews);
 		};
-		if(totalBlockCount < config.PREVIEW_BLOCK_LIMIT) {
+		if(totalBlockCount < config.PREVIEW_BLOCK_LIMIT && removeFalsies(blockPalette).length < 250) {
 			showPreview();
 		} else {
 			let message = document.createElement("div");

--- a/src/HoloPrint.js
+++ b/src/HoloPrint.js
@@ -143,7 +143,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 	
 	console.log("Texture UVs:", textureAtlas.uvs);
 	let polyMeshTemplatePalette = unresolvedPolyMeshTemplatePalette.map(polyMeshTemplate => BlockGeoMaker.resolveTemplateFaceUvs(polyMeshTemplate, textureAtlas));
-	console.log("Bone template palette with resolved UVs:", polyMeshTemplatePalette);
+	console.log("Poly mesh template palette with resolved UVs:", polyMeshTemplatePalette);
 	
 	let structureGeoTemplate = hologramGeo["minecraft:geometry"][0];
 	hologramGeo["minecraft:geometry"].splice(0, 1);
@@ -185,12 +185,12 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 						let paletteI = blockPaletteIndices[blockI];
 						if(!(paletteI in polyMeshTemplatePalette)) {
 							if(paletteI in blockPalette) {
-								console.error(`A bone template wasn't made for blockPalette[${paletteI}] = ${blockPalette[paletteI]["name"]}!`);
+								console.error(`A poly mesh template wasn't made for blockPalette[${paletteI}] = ${blockPalette[paletteI]["name"]}!`);
 							}
 							return;
 						}
 						let polyMeshTemplateFaces = polyMeshTemplatePalette[paletteI];
-						// console.table({x, y, z, i, paletteI, boneTemplate});
+						// console.table({x, y, z, i, paletteI, polyMeshTemplateFaces});
 						
 						let blockCoordinateName = `b_${x}_${y}_${z}`;
 						let geoSpaceBlockPos = [-16 * x - 8, 16 * y, 16 * z - 8]; // I got these values from trial and error with blockbench (which makes the x negative I think. it's weird.)
@@ -1811,12 +1811,6 @@ function stringifyWithFixedDecimals(value) {
  * @typedef {object} PolyMeshTemplateVertexWithUv
  * @property {Vec3} pos
  * @property {Vec2} uv
- */
-/**
- * @typedef {object} BoneTemplate An unpositioned bone for geometry files without name or parent. All units/coordinates are relative to (0, 0, 0).
- * @property {Vec3} [pivot] The block's center point of rotation
- * @property {Vec3} [rotation] The block's rotation
- * @property {Array} cubes
  */
 /**
  * @typedef {object} TextureReference A texture reference, made in BlockGeoMaker.js and turned into a texture in TextureAtlas.js.

--- a/src/HoloPrint.js
+++ b/src/HoloPrint.js
@@ -218,7 +218,6 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 				}
 			}
 			let layerName = `l_${y}`;
-			/** @type {import("@bridge-editor/model-viewer").IBoneSchema} */
 			let layerBone = {
 				"name": layerName,
 				"parent": "hologram_offset_wrapper",
@@ -439,7 +438,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 	});
 	
 	await Promise.all(packFiles.map(([fileName, fileContents, comment]) => {
-		/** @type {import("@zip.js/zip.js").ZipWriterAddDataOptions} */
+		/** @type {ZipWriterAddDataOptions} */
 		let options = {
 			comment,
 			level: config.COMPRESSION_LEVEL
@@ -1715,6 +1714,7 @@ function stringifyWithFixedDecimals(value) {
 	});
 }
 
+/** @import { ZipWriterAddDataOptions } from "@zip.js/zip.js" */
 /**
  * @typedef {object} HoloPrintConfig An object for storing HoloPrint config options.
  * @property {Array<string>} IGNORED_BLOCKS

--- a/src/HoloPrint.js
+++ b/src/HoloPrint.js
@@ -242,7 +242,7 @@ export async function makePack(structureFiles, config = {}, resourcePackStack, p
 		let spawnAnimationMaker = new SpawnAnimationMaker(config, [1, maxHeight, 1]);
 		for(let y = 0; y < maxHeight; y++) {
 			let layerName = `l_${y}`;
-			spawnAnimationMaker.addBone(layerName, [0, y, 0], [0, 16 * y, 0]);
+			spawnAnimationMaker.addBone(layerName, [0, y, 0], [0, 16 * y, -16]);
 		}
 		hologramAnimations["animations"]["animation.armor_stand.hologram.spawn"] = spawnAnimationMaker.makeAnimation();
 	}

--- a/src/MaterialList.js
+++ b/src/MaterialList.js
@@ -258,9 +258,4 @@ export default class MaterialList extends AsyncFactory {
 	}
 }
 
-/**
- * @typedef {import("./HoloPrint.js").MaterialListEntry} MaterialListEntry
- */
-/**
- * @typedef {import("./BlockGeoMaker.js").Block} Block
- */
+/** @import { MaterialListEntry, Block } from "./HoloPrint.js" */

--- a/src/PolyMeshMaker.js
+++ b/src/PolyMeshMaker.js
@@ -1,0 +1,50 @@
+import { JSONSet } from "./utils.js";
+
+export default class PolyMeshMaker {
+	/** @type {JSONSet<Vec3>} */
+	#positions = new JSONSet();
+	/** @type {JSONSet<Vec3>} */
+	#normals = new JSONSet();
+	/** @type {JSONSet<Vec2>} */
+	#uvs = new JSONSet();
+	/** @type {Array<PolyMeshFace>} */
+	#polys = [];
+	
+	/**
+	 * Adds templates faces to the poly mesh, with an optional position offset.
+	 * @param {Array<PolyMeshTemplateFaceWithUvs>} faces
+	 * @param {Vec3} [positionOffset]
+	 */
+	add(faces, positionOffset = [0, 0, 0]) {
+		faces.forEach(face => {
+			let newPoly = [];
+			let normalI = this.#normals.addI(face["normal"]);
+			for(let i = 0; i < 4; i++) {
+				let vertex = face["vertices"][i];
+				let pos = [vertex["pos"][0] + positionOffset[0], vertex["pos"][1] + positionOffset[1], vertex["pos"][2] + positionOffset[2]];
+				let posI = this.#positions.addI(pos);
+				let uvI = this.#uvs.addI(vertex["uv"]);
+				newPoly.push([posI, normalI, uvI]);
+			}
+			this.#polys.push(newPoly);
+		});
+	}
+	/** @returns {PolyMesh} */
+	export() {
+		return {
+			"normalized_uvs": true,
+			"positions": Array.from(this.#positions),
+			"normals": Array.from(this.#normals),
+			"uvs": Array.from(this.#uvs),
+			"polys": this.#polys
+		};
+	}
+	clear() {
+		this.#positions.clear();
+		this.#normals.clear();
+		this.#uvs.clear();
+		this.#polys = [];
+	}
+}
+
+/** @import { Vec3, Vec2, PolyMeshTemplateFaceWithUvs, PolyMeshFace, PolyMesh } from "./HoloPrint.js" */

--- a/src/PolyMeshMaker.js
+++ b/src/PolyMeshMaker.js
@@ -1,33 +1,80 @@
-import { JSONSet } from "./utils.js";
+import { addVec3, JSONSet } from "./utils.js";
+
+// InternalError is only in Firefox. This function will be run possibly hundreds of thousands of times so it's imperative that this is fast!
+const stringifyVec2 = "InternalError" in window? vec => vec[0] + "," + vec[1] : vec => `${vec[0]},${vec[1]}`;
+const stringifyVec3 = "InternalError" in window? vec => vec[0] + "," + vec[1] + "," + vec[2] : vec => `${vec[0]},${vec[1]},${vec[2]}`;
 
 export default class PolyMeshMaker {
+	templatePalette;
 	/** @type {JSONSet<Vec3>} */
-	#positions = new JSONSet();
+	#positions = new JSONSet([], stringifyVec3);
 	/** @type {JSONSet<Vec3>} */
-	#normals = new JSONSet();
+	#normals = new JSONSet([], stringifyVec3);
 	/** @type {JSONSet<Vec2>} */
-	#uvs = new JSONSet();
+	#uvs = new JSONSet([], stringifyVec2);
 	/** @type {Array<PolyMeshFace>} */
 	#polys = [];
+	/** @type {Map<number, Array<number>>} */
+	#paletteNormals = new Map();
+	/** @type {Map<number, Array<number>>} */
+	#paletteUvs = new Map();
 	
+	/** @param {Array<Array<PolyMeshTemplateFaceWithUvs>>} [templatePalette] */
+	constructor(templatePalette = []) {
+		this.templatePalette = templatePalette;
+	}
 	/**
 	 * Adds templates faces to the poly mesh, with an optional position offset.
 	 * @param {Array<PolyMeshTemplateFaceWithUvs>} faces
 	 * @param {Vec3} [positionOffset]
+	 * @returns {[Array<number>, Array<number>]} Indices of the normals and uvs for the added faces.
 	 */
 	add(faces, positionOffset = [0, 0, 0]) {
-		faces.forEach(face => {
+		let normalIndices = [];
+		let uvIndices = [];
+		for(let faceI = 0; faceI < faces.length; faceI++) {
+			let face = faces[faceI];
 			let newPoly = [];
 			let normalI = this.#normals.addI(face["normal"]);
-			for(let i = 0; i < 4; i++) {
-				let vertex = face["vertices"][i];
-				let pos = [vertex["pos"][0] + positionOffset[0], vertex["pos"][1] + positionOffset[1], vertex["pos"][2] + positionOffset[2]];
+			normalIndices[faceI] = normalI;
+			for(let vertexI = 0; vertexI < 4; vertexI++) {
+				let vertex = face["vertices"][vertexI];
+				let pos = addVec3(vertex["pos"], positionOffset);
 				let posI = this.#positions.addI(pos);
 				let uvI = this.#uvs.addI(vertex["uv"]);
+				uvIndices[faceI * 4 + vertexI] = uvI;
 				newPoly.push([posI, normalI, uvI]);
 			}
 			this.#polys.push(newPoly);
-		});
+		}
+		return [normalIndices, uvIndices];
+	}
+	/**
+	 * Adds an entry from the template palette to the poly mesh, with an optional position offset.
+	 * @param {number} paletteI
+	 * @param {Vec3} [positionOffset]
+	 */
+	addPaletteEntry(paletteI, positionOffset = [0, 0, 0]) {
+		let faces = this.templatePalette[paletteI];
+		if(this.#paletteNormals.has(paletteI)) { // since the same blocks have the same normals and uv coordinates, they can be cached
+			let normalIndices = this.#paletteNormals.get(paletteI);
+			let uvIndices = this.#paletteUvs.get(paletteI);
+			for(let faceI = 0; faceI < faces.length; faceI++) {
+				let face = faces[faceI];
+				let newPoly = [];
+				for(let vertexI = 0; vertexI < 4; vertexI++) {
+					let vertex = face["vertices"][vertexI];
+					let pos = addVec3(vertex["pos"], positionOffset);
+					let posI = this.#positions.addI(pos);
+					newPoly.push([posI, normalIndices[faceI], uvIndices[faceI * 4 + vertexI]]);
+				}
+				this.#polys.push(newPoly);
+			}
+		} else {
+			let [normalIndices, uvIndices] = this.add(faces, positionOffset);
+			this.#paletteNormals.set(paletteI, normalIndices);
+			this.#paletteUvs.set(paletteI, uvIndices);
+		}
 	}
 	/** @returns {PolyMesh} */
 	export() {
@@ -44,6 +91,8 @@ export default class PolyMeshMaker {
 		this.#normals.clear();
 		this.#uvs.clear();
 		this.#polys = [];
+		this.#paletteNormals.clear();
+		this.#paletteUvs.clear();
 	}
 }
 

--- a/src/PreviewRenderer.js
+++ b/src/PreviewRenderer.js
@@ -530,7 +530,7 @@ export default class PreviewRenderer extends AsyncFactory {
 		let polyMeshMaker = new PolyMeshMaker();
 		polyMeshMaker.add(polyMeshTemplate);
 		let polyMesh = polyMeshMaker.export();
-		let i = 0;
+		let i = 0; // this bit is adapted from https://github.com/bridge-core/model-viewer/blob/main/lib/PolyMesh.ts#L45
 		let positions = [], normals = [], uvs = [], indices = [];
 		polyMesh["polys"].forEach(face => {
 			face.forEach(([posIndex, normalIndex, uvIndex]) => {

--- a/src/PreviewRenderer.js
+++ b/src/PreviewRenderer.js
@@ -83,7 +83,7 @@ export default class PreviewRenderer extends AsyncFactory {
 	 * Create a preview renderer for a completed geometry file.
 	 * @param {Node} cont
 	 * @param {string} packName
-	 * @param {import("./TextureAtlas.js").default} textureAtlas
+	 * @param {TextureAtlas} textureAtlas
 	 * @param {I32Vec3} structureSize
 	 * @param {Array<Block>} blockPalette
 	 * @param {Array<Array<PolyMeshTemplateFaceWithUvs>>} polyMeshTemplatePalette
@@ -131,7 +131,7 @@ export default class PreviewRenderer extends AsyncFactory {
 			});
 		}
 		if(this.options.showOptions) {
-			/** @type {import("./components/LilGui.js").default} */
+			/** @type {LilGui} */
 			let guiEl = document.createElement("lil-gui");
 			this.cont.appendChild(guiEl);
 			this.#optionsGui = guiEl.gui;
@@ -311,7 +311,7 @@ export default class PreviewRenderer extends AsyncFactory {
 	}
 	/**
 	 * Adds the localised name to a lil-gui controller.
-	 * @template {import("lil-gui").Controller} T
+	 * @template {Controller} T
 	 * @param {T} controller
 	 * @param {string} translationKey
 	 * @returns {T}
@@ -590,3 +590,6 @@ export default class PreviewRenderer extends AsyncFactory {
 }
 
 /** @import { I32Vec3, Vec3, Block, PreviewPointLight, PolyMeshTemplateFaceWithUvs} from "./HoloPrint.js" */
+/** @import TextureAtlas from "./TextureAtlas.js" */
+/** @import LilGui from "./components/LilGui.js" */
+/** @import { Controller } from "lil-gui" */

--- a/src/SpawnAnimationMaker.js
+++ b/src/SpawnAnimationMaker.js
@@ -132,18 +132,4 @@ export default class SpawnAnimationMaker {
 	}
 }
 
-/**
- * @typedef {import("./HoloPrint.js").HoloPrintConfig} HoloPrintConfig
- */
-/**
- * @typedef {import("./HoloPrint.js").Vec3} Vec3
- */
-/**
- * @typedef {import("./HoloPrint.js").I32Vec3} I32Vec3
- */
-/**
- * @typedef {import("./HoloPrint.js").SpawnAnimationBone} SpawnAnimationBone
- */
-/**
- * @typedef {import("./HoloPrint.js").MinecraftAnimation} MinecraftAnimation
- */
+/** @import { HoloPrintConfig, Vec3, I32Vec3, SpawnAnimationBone, MinecraftAnimation } from "./HoloPrint.js" */

--- a/src/SpawnAnimationMaker.js
+++ b/src/SpawnAnimationMaker.js
@@ -10,7 +10,7 @@ export default class SpawnAnimationMaker {
 	/**
 	 * Creates a SpawnAnimationMaker for managing the spawn animation.
 	 * @param {HoloPrintConfig} config
-	 * @param {I32Vec3} structureSize
+	 * @param {I32Vec3 | Vec3} structureSize
 	 */
 	constructor(config, structureSize) {
 		this.config = config;

--- a/src/TextureAtlas.js
+++ b/src/TextureAtlas.js
@@ -605,18 +605,4 @@ export default class TextureAtlas extends AsyncFactory {
 	}
 }
 
-/**
- * @typedef {import("./HoloPrint.js").TextureReference} TextureReference
- */
-/**
- * @typedef {import("./HoloPrint.js").TextureFragment} TextureFragment
- */
-/**
- * @typedef {import("./HoloPrint.js").ImageFragment} ImageFragment
- */
-/**
- * @typedef {import("./HoloPrint.js").HoloPrintConfig} HoloPrintConfig
- */
-/**
- * @typedef {import("./HoloPrint.js").Vec3} Vec3
- */
+/** @import { TextureReference, TextureFragment, ImageFragment, HoloPrintConfig, Vec3, Vec2, Rectangle } from "./HoloPrint.js" */

--- a/src/index.html
+++ b/src/index.html
@@ -75,7 +75,7 @@
 			{
 				"imports": {
 					"nbtify-readonly-typeless": "https://esm.sh/nbtify-readonly-typeless@1.1.2?keep-names",
-					"mcbe-leveldb-reader": "https://esm.sh/mcbe-leveldb-reader@1.0.3?exports=extractStructureFilesFromMcworld",
+					"mcbe-leveldb-reader": "https://esm.sh/mcbe-leveldb-reader@2.0.0?exports=extractStructureFilesFromMcworld",
 					"tga-js": "https://esm.sh/tga-js@1.1.1",
 					"potpack": "https://esm.sh/potpack@2.0.0",
 					"deepmerge": "https://esm.sh/deepmerge@4.3.1",

--- a/src/index.html
+++ b/src/index.html
@@ -80,11 +80,10 @@
 					"potpack": "https://esm.sh/potpack@2.0.0",
 					"deepmerge": "https://esm.sh/deepmerge@4.3.1",
 					"@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2?exports=createClient",
-					"three": "https://esm.sh/three@0.147.0",
-					"three/addons/": "https://esm.sh/three@0.177.0/addons/",
+					"three": "https://esm.sh/three@0.177.0",
+					"three/examples/jsm/": "https://esm.sh/three@0.177.0/examples/jsm/",
 					"stats.js": "https://esm.sh/stats.js@0.17.0",
 					"lil-gui": "https://esm.sh/lil-gui@0.20",
-					"@bridge-editor/model-viewer": "https://esm.sh/@bridge-editor/model-viewer@0.8.1?exports=StandaloneModelViewer,Model",
 					"@zip.js/zip.js": "https://esm.sh/@zip.js/zip.js@2.7.60?exports=ZipWriter,TextReader,BlobWriter,BlobReader,ZipReader",
 					"strip-json-comments": "https://esm.sh/strip-json-comments@5.0.1"
 				}

--- a/src/index.js
+++ b/src/index.js
@@ -528,7 +528,7 @@ async function makePack(structureFiles, localResourcePacks) {
 	
 	let formData = new FormData(generatePackForm);
 	let authors = removeFalsies(formData.get("author").split(",").map(x => x.trim()));
-	/** @type {import("./HoloPrint.js").HoloPrintConfig} */
+	/** @type {HoloPrintConfig} */
 	let config = {
 		IGNORED_BLOCKS: removeFalsies(formData.get("ignoredBlocks").split(/\W/)),
 		SCALE: formData.get("scale") / 100,
@@ -620,3 +620,5 @@ async function makePack(structureFiles, localResourcePacks) {
 	
 	generatePackFormSubmitButton.disabled = false;
 }
+
+/** @import { HoloPrintConfig } from "./HoloPrint.js" */

--- a/src/packTemplate/animations/armor_stand.hologram.animation.json
+++ b/src/packTemplate/animations/armor_stand.hologram.animation.json
@@ -18,7 +18,7 @@ I also wonder if we could have a "rotation lock" option which makes the hologram
 						// Snap to nearest block. Unfortunately looks glitchy when moving since it takes a tick for the position to update.
 						// x and z of armor stands is +0.5
 						0, //"-16 * (q.position(0) - 0.5 - math.floor(q.position(0) - 0.5))",
-						"-16 * (q.position(1) - math.floor(q.position(1)))",
+						"-16 * (q.position(1) - math.floor(q.position(1))) - 0.125", // entity models are 0.125px above blocks for some reason
 						0 //"-16 * (q.position(2) - math.floor(q.position(2)))"
 					],
 					"rotation": [

--- a/src/utils.js
+++ b/src/utils.js
@@ -922,6 +922,4 @@ export function createCustomError(name) {
 }
 export const UserError = createCustomError("UserError");
 
-/**
- * @typedef {import("./HoloPrint.js").Vec3} Vec3
- */
+/** @import { Vec2, Vec3 } from "./HoloPrint.js" */

--- a/src/utils.js
+++ b/src/utils.js
@@ -750,19 +750,23 @@ function parseJsonBigIntSafe(value) { // this function is unused but I'm keeping
  * @extends {Set<T>}
  */
 export class JSONSet extends Set {
+	stringify = stringifyJsonBigIntSafe;
 	/** @type {Map<string, number>} */
 	#indices = new Map();
 	#actualValues = new Map();
-	constructor(values) {
+	constructor(values, stringifyFunc) {
 		super();
 		values?.forEach(value => this.add(value));
+		if(stringifyFunc) {
+			this.stringify = stringifyFunc;
+		}
 	}
 	/** Not part of regular sets! Constant time indexing. */
 	indexOf(value) {
-		return this.#indices.get(this.#stringify(value));
+		return this.#indices.get(this.stringify(value));
 	}
 	addI(value) {
-		let stringifiedValue = this.#stringify(value);
+		let stringifiedValue = this.stringify(value);
 		super.add(stringifiedValue);
 		if(!this.#actualValues.has(stringifiedValue)) {
 			this.#actualValues.set(stringifiedValue, structuredClone(value));
@@ -772,7 +776,7 @@ export class JSONSet extends Set {
 		return this.#indices.get(stringifiedValue);
 	}
 	add(value) {
-		let stringifiedValue = this.#stringify(value);
+		let stringifiedValue = this.stringify(value);
 		if(!this.#actualValues.has(stringifiedValue)) {
 			this.#actualValues.set(stringifiedValue, structuredClone(value));
 			this.#indices.set(stringifiedValue, this.size);
@@ -780,10 +784,10 @@ export class JSONSet extends Set {
 		return super.add(stringifiedValue);
 	}
 	delete(value) {
-		return super.delete(this.#stringify(value));
+		return super.delete(this.stringify(value));
 	}
 	has(value) {
-		return super.has(this.#stringify(value))
+		return super.has(this.stringify(value))
 	}
 	clear() {
 		this.#indices.clear();
@@ -813,9 +817,6 @@ export class JSONSet extends Set {
 	}
 	values() {
 		return this[Symbol.iterator]();
-	}
-	#stringify(value) {
-		return stringifyJsonBigIntSafe(value);
 	}
 }
 export class JSONMap extends Map { // very barebones

--- a/tests/headlessBrowserTestRunner.js
+++ b/tests/headlessBrowserTestRunner.js
@@ -103,6 +103,7 @@ async function setupBrowserAndPage(status) {
 		width: 1920,
 		height: 1080
 	});
+	page.setDefaultTimeout(5000);
 	page.on("console", log => {
 		let logOrigin = log.location()?.url;
 		let logText = log.text();


### PR DESCRIPTION
- Fix https://github.com/SuperLlama88888/holoprint/issues/204: Put all blocks in a layer into one bone. Using poly_mesh instead of cubes makes the math for rotations much easier, especially when there are multiple rotations. It also required a really large refactor...
- Fix https://github.com/SuperLlama88888/holoprint/issues/12: Since all faces are controlled individually now, all faces can be cropped individually, removing the duplicate texture references
- Improve performance on website during pack creation
- Make ghost blocks be scaled towards the center of mass rather than the center of the block position, meaning they should be covered when the actual blocks are placed. (Does this count as physically-based rendering?)
- Remove dependency on @bridge-core/model-viewer by making geometry from poly_mesh directly
- Remove duplicate Three.js library import from multiple versions
- Minify JSDoc type imports
- Shorten default timeout on Puppeteer tests
- Update to newer version of MCBE-LevelDB-reader to remove unneeded NBTify import