### PR TITLE
feat(data): bump Mojang vanillaData to v1.26.40.26-preview

### DIFF
--- a/src/fetchers.js
+++ b/src/fetchers.js
@@ -1,7 +1,7 @@
 import { lazyLoadAsyncFunctionFactory, max, sleep } from "./utils.js";
 
 export default {
-	vanillaData: createLazyCachingFetcher("VanillaDataFetcher", "Mojang", "bedrock-samples", "v1.21.120.22-preview"),
+	vanillaData: createLazyCachingFetcher("VanillaDataFetcher", "Mojang", "bedrock-samples", "v1.26.40.26-preview"),
 	bedrockData: createLazyCachingFetcher("BedrockData", "pmmp", "BedrockData", "6.1.0+bedrock-1.21.111"),
 	bedrockBlockUpgradeSchema: createLazyCachingFetcher("BlockUpgrader", "SuperLlama88888", "BedrockBlockUpgradeSchema", "5.2.0+bedrock-1.21.110")
 };


### PR DESCRIPTION
## What

This pull request updates the version of the `vanillaData` fetcher to use a newer preview release. No other changes are included.

- Updated the `vanillaData` fetcher in `src/fetchers.js` to reference the `v1.26.40.26-preview` version of the `bedrock-samples` repository, replacing the previous `v1.21.120.22-preview` version.

## Why

With the new 26.30 update, many blocks were added, like sulfur and cinnabar. With this change, HoloPrint can fetch the new blocks from `bedrock-samples` and prevent errors like these:

```text
No blocks.json entry for sulfur_spike
No blocks.json entry for potent_sulfur
Cannot find any translation key for potent_sulfur!
Cannot find any translation key for sulfur_spike!
```

And yes, I'm already exporting structures with the new blocks lol.